### PR TITLE
feat: text promt add. "do not output any other content."

### DIFF
--- a/magic_pdf/config/prompts.py
+++ b/magic_pdf/config/prompts.py
@@ -58,7 +58,7 @@ class ModelNames:
 
 
 class Prompts:
-    TEXT = "Please output the text content from the image."
+    TEXT = "Please output the text content from the image. do not output any other content."
     FORMULA = "Please write out the expression of the formula in the image using LaTeX format."
     IMAGE = "Write a caption describing the image."
     TABLE = "Parse the table in the image."


### PR DESCRIPTION
feat:
"The text content from the image is" 와 같은 explain text가 출력되지 않게 간단한 prompt를 추가했습니다.